### PR TITLE
Fix some whitespace issues in frontends template

### DIFF
--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -30,7 +30,7 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
     {%- if item.acl is defined -%}
     {%- for acl in item.acl -%}
          acl {{ acl.name }} {{ acl.condition }}
-    {% endfor %}
+    {% endfor -%}
     {% endif -%}
 
     {%- if item.reqadd is defined -%}
@@ -83,8 +83,7 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
     {% endif -%}
 
     {%- if item.use_backend is defined -%}
-        {% for backend in item.use_backend %}
-            use_backend {{ backend.name }} {{ backend.condition }}
-        {% endfor %}
+    {%- for backend in item.use_backend -%}
+         use_backend {{ backend.name }} {{ backend.condition }}
+    {% endfor -%}
     {% endif -%}
-


### PR DESCRIPTION
Without those fixes some extraneous indentation could be inserted either in directives after  the`acl`  directives block, or for each `use_backend` directive.
