### PR TITLE
Fix the configuration of the webstats ui

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,16 +26,16 @@
 
 ## PACKAGE INSTALL
 
-- name: 'Check epel repo'
-  shell: yum repolist | grep -qi EPEL
-  register: epel_repo_check
-  when: ansible_pkg_mgr == 'yum'
-
-- name: 'Add epel repo'
-  template: src=epel.repo
-        dest=/etc/yum.repos.d/epel.repo
-        owner=root group=root mode=0644
-  when: ansible_pkg_mgr == 'yum' and epel_repo_check.rc != 0
+# - name: 'Check epel repo'
+#   shell: yum repolist | grep -qi EPEL
+#   register: epel_repo_check
+#   when: ansible_pkg_mgr == 'yum'
+#
+# - name: 'Add epel repo'
+#   template: src=epel.repo
+#         dest=/etc/yum.repos.d/epel.repo
+#         owner=root group=root mode=0644
+#   when: ansible_pkg_mgr == 'yum' and epel_repo_check.rc != 0
 
 - name: 'Installs haproxy as well as socat for socket api'
   yum: name={{ item }} state=latest
@@ -143,6 +143,10 @@
 - name: 'Build up the default config'
   template: src=defaults.cfg dest={{ etc_prefix }}/haproxy/compiled/02-defaults.cfg
   when: haproxy_defaults is defined
+
+- name: 'Build the web stats config'
+  template: src=web_stats.cfg dest={{ etc_prefix }}/haproxy/compiled/07-web_stats.cfg
+  when: haproxy_web_stats is defined
 
 ## ASSEMBLE FINAL CONFIG
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,16 +26,16 @@
 
 ## PACKAGE INSTALL
 
-# - name: 'Check epel repo'
-#   shell: yum repolist | grep -qi EPEL
-#   register: epel_repo_check
-#   when: ansible_pkg_mgr == 'yum'
-#
-# - name: 'Add epel repo'
-#   template: src=epel.repo
-#         dest=/etc/yum.repos.d/epel.repo
-#         owner=root group=root mode=0644
-#   when: ansible_pkg_mgr == 'yum' and epel_repo_check.rc != 0
+- name: 'Check epel repo'
+  shell: yum repolist | grep -qi EPEL
+  register: epel_repo_check
+  when: ansible_pkg_mgr == 'yum'
+
+- name: 'Add epel repo'
+  template: src=epel.repo
+        dest=/etc/yum.repos.d/epel.repo
+        owner=root group=root mode=0644
+  when: ansible_pkg_mgr == 'yum' and epel_repo_check.rc != 0
 
 - name: 'Installs haproxy as well as socat for socket api'
   yum: name={{ item }} state=latest

--- a/templates/defaults.cfg
+++ b/templates/defaults.cfg
@@ -24,26 +24,6 @@ defaults
 {% if haproxy_defaults.maxconn is defined -%}
     maxconn {{ haproxy_defaults.maxconn }}
 {% endif -%}
-{% if haproxy_defaults.stats is defined %}
-{% if haproxy_defaults.stats.enabled is defined and haproxy_defaults.stats.enabled == True %}
-    stats enable
-{% endif -%}
-{% if haproxy_defaults.stats.hide_version is defined and haproxy_defaults.stats.hide_version == true %}
-    stats hide-version
-{% endif -%}
-{% if haproxy_defaults.stats.uri is defined %}
-    stats uri {{ haproxy_defaults.stats.uri }}
-{% endif -%}
-{% if haproxy_defaults.stats.realm is defined %}
-    stats realm {{ haproxy_defaults.stats.realm }}
-{% endif -%}
-{% if haproxy_defaults.stats.auth is defined %}
-    stats auth {{ haproxy_defaults.stats.auth }}
-{% endif -%}
-{% if haproxy_defaults.stats.refresh is defined %}
-    stats refresh {{ haproxy_defaults.stats.refresh }}
-{% endif -%}
-{% endif %}
 {% if haproxy_defaults.options is defined %}
 {% for option in haproxy_defaults.options %}
     option {{ option }}
@@ -83,4 +63,3 @@ defaults
     http-check send-state
 {% endif -%}
 {% endif -%}
-

--- a/templates/web_stats.cfg
+++ b/templates/web_stats.cfg
@@ -1,6 +1,6 @@
 
 {% if haproxy_web_stats is defined %}
-listen stats *:{{ port | default(1936) }}
+listen stats *:{{ haproxy_web_stats.port | default(1936) }}
 {% if haproxy_web_stats.enabled is defined and haproxy_web_stats.enabled == true %}
     stats enable
 {% endif -%}

--- a/templates/web_stats.cfg
+++ b/templates/web_stats.cfg
@@ -1,0 +1,22 @@
+
+{% if haproxy_web_stats is defined %}
+listen stats *:{{ port | default(1936) }}
+{% if haproxy_web_stats.enabled is defined and haproxy_web_stats.enabled == true %}
+    stats enable
+{% endif -%}
+{% if haproxy_web_stats.hide_version is defined and haproxy_web_stats.hide_version == true %}
+    stats hide-version
+{% endif -%}
+{% if haproxy_web_stats.uri is defined %}
+    stats uri {{ haproxy_web_stats.uri }}
+{% endif -%}
+{% if haproxy_web_stats.realm is defined %}
+    stats realm {{ haproxy_web_stats.realm }}
+{% endif -%}
+{% if haproxy_web_stats.auth is defined %}
+    stats auth {{ haproxy_web_stats.auth }}
+{% endif -%}
+{% if haproxy_web_stats.refresh is defined %}
+    stats refresh {{ haproxy_web_stats.refresh }}
+{% endif -%}
+{% endif %}

--- a/templates/web_stats.cfg
+++ b/templates/web_stats.cfg
@@ -1,6 +1,7 @@
-
 {% if haproxy_web_stats is defined %}
 listen stats *:{{ haproxy_web_stats.port | default(1936) }}
+    mode http
+    stats realm Haproxy\ Statistics
 {% if haproxy_web_stats.enabled is defined and haproxy_web_stats.enabled == true %}
     stats enable
 {% endif -%}


### PR DESCRIPTION
This fix the configuration of the Web Stats UI that requires a config like:

```
listen stats *:1936
    stats enable
    stats uri /
    stats hide-version
    stats auth some user:password
```

This pull-request add the new variables:

``` yaml
- role: ansible-haproxy
  haproxy_web_stats:
        port: 1935
        enabled: True
        uri: '/'
        auth: 'admin:admin'
```
