### PR TITLE
Only set SSL parameters on bind if needed

### DIFF
--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -1,12 +1,13 @@
 #{{ ansible_managed }}
 frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if item.port is defined %}:{{ item.port }}{% endif %}
 
-    {% if item.bind is defined -%}
-    {%- for bind in item.bind -%}
-        bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl crt {{ item.ssl.cert }}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}
-
+    {% if item.binds is defined -%}
+    {%- for bind in item.binds -%}
+        bind {{ bind.bind }}{% if bind.ssl is defined and bind.ssl == True %}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl crt {{ item.ssl.cert }}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}{% endif %}
+        
     {% endfor -%}
     {% endif -%}
+
 
     {% if item.mode is defined -%}
         mode {{ item.mode }}

--- a/templates/listen.cfg
+++ b/templates/listen.cfg
@@ -1,8 +1,8 @@
 #{{ ansible_managed }}
 listen {{ item.name }}
-{% if item.bind is defined %}
-{% for binding in item.bind %}
-   bind {{ binding }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl crt {{ item.ssl.cert }}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}
+{% if item.binds is defined %}
+{% for bind in item.bind %}
+   bind {{ bind.bind }}{% if bind.ssl is defined and bind.ssl == True %}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl crt {{ item.ssl.cert }}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}{% endif %}
 
 {% endfor %}
 {% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -50,9 +50,11 @@ empty: true
 #haproxy_frontends:
 #  - name:
 #    ip:
-#    bind:
-#      - 192.168.1.1:80
-#      - 192.168.1.2:81
+#    binds:
+#      - bind: 192.168.1.1:80
+#        ssl: false
+#      - bind: 192.168.1.1:443
+#        ssl: true
 #    ssl:
 #      cert: /etc/ssl/private/cert.pem
 #      ciphers: 'RC4-SHA:AES128-SHA:AES:!ADH:!aNULL:!DH:!EDH:!eNULL'


### PR DESCRIPTION
If we set an SSL block with cipher suite, etc... the template will apply it for every single bind configured. This can lead to SSL applied even on bind: *:80 where it's not wanted.

To prevent for ssl to be applied everywhere, we define a new block structure for binds in the frontend/listen configuration area : 

binds:
    - bind: 192.168.1.1:80
    ssl: false
    - bind: 192.168.1.1:443
    ssl: true

As defined in the example configuration, binds is a list of bind, with a bind.ssl boolean that defines if we want ssl to be applied or not.

The generated haproxy configuration will then be : 

frontend f_example
    bind *:80
    bind *:443 ssl crt /etc/ssl/private/domain.tld.pem ciphers ECDHE-ECDSA-AES256-GCM-SHA384:...
