### PR TITLE
bugfix/#43 - template for haproxy_listen

### DIFF
--- a/templates/defaults.cfg
+++ b/templates/defaults.cfg
@@ -10,7 +10,6 @@ defaults
 {% if log.format is defined %}
     log-format {{ log.format }}
 {% endif %}
-
 {% endfor %}
 {% endif %}
 {% if haproxy_defaults.retries is defined %}
@@ -21,9 +20,9 @@ defaults
     timeout {{ condition.param }} {{ condition.value }}
 {% endfor %}
 {% endif -%}
-{% if haproxy_defaults.maxconn is defined -%}
+{% if haproxy_defaults.maxconn is defined %}
     maxconn {{ haproxy_defaults.maxconn }}
-{% endif -%}
+{% endif %}
 {% if haproxy_defaults.stats is defined %}
 {% if haproxy_defaults.stats.enabled is defined and haproxy_defaults.stats.enabled == True %}
     stats enable
@@ -83,4 +82,8 @@ defaults
     http-check send-state
 {% endif -%}
 {% endif -%}
-
+{% if haproxy_defaults.extra is defined %}
+{% for parameter in haproxy_defaults.extra %}
+    {{ parameter }}
+{% endfor %}
+{% endif -%}

--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -45,4 +45,9 @@ global
 {% endif %}
 {% endfor %}
 {% endif %}
+{% if haproxy_global.extra is defined %}
+{% for parameter in haproxy_global.extra %}
+    {{ parameter }}
+{% endfor %}
+{% endif -%}
 

--- a/templates/listen.cfg
+++ b/templates/listen.cfg
@@ -2,7 +2,7 @@
 listen {{ item.name }}
 {% if item.bind is defined %}
 {% for binding in item.bind %}
-   bind {{ binding }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl crt {{ item.ssl.cert }}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}
+    bind {{ binding }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl crt {{ item.ssl.cert }}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}
 
 {% endfor %}
 {% endif -%}
@@ -41,6 +41,11 @@ listen {{ item.name }}
 {% if item.options is defined %}
 {% for option in item.options %}
     option {{ option }}
+{% endfor %}
+{% endif -%}
+{% if item.extra is defined %}
+{% for parameter in item.extra %}
+    {{ parameter }}
 {% endfor %}
 {% endif -%}
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -105,6 +105,7 @@ empty: true
 #haproxy_listen:
 #  - name:
 #    bind:
+#      - ip:port
 #    ssl:
 #      cert: /etc/ssl/private/cert.pem
 #      ciphers: 'RC4-SHA:AES128-SHA:AES:!ADH:!aNULL:!DH:!EDH:!eNULL'


### PR DESCRIPTION
- Align
- keyword 'http-send-name-header' and 'http-check-except'
- Sample for bind in haproxy_listen
- add extra part for any options which are not included, currently only for global, default and listens.
