### PR TITLE
Support global `tune` parameters

### DIFF
--- a/filter_plugins/flatten.py
+++ b/filter_plugins/flatten.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+def flatten(d, separator='.'):
+    """
+    Flatten a dictionary `d` by joining nested keys with `separator`.
+
+    Slightly modified from <http://codereview.stackexchange.com/a/21035>.
+
+    >>> flatten({'eggs': 'spam', 'sausage': {'eggs': 'bacon'}, 'spam': {'bacon': {'sausage': 'spam'}}})
+    {'spam.bacon.sausage': 'spam', 'eggs': 'spam', 'sausage.eggs': 'bacon'}
+    """
+    def items():
+        for k, v in d.items():
+            try:
+                for sub_k, sub_v in flatten(v, separator).items():
+                    yield separator.join([k, sub_k]), sub_v
+            except AttributeError:
+                yield k, v
+    return dict(items())
+
+
+class FilterModule(object):
+    def filters(self):
+        return {'flatten': flatten}

--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -51,3 +51,8 @@ global
 {% if haproxy_global.ssl_default_bind_ciphers is defined %}
     ssl-default-bind-ciphers {{ haproxy_global.ssl_default_bind_ciphers }}
 {% endif -%}
+{% if haproxy_global.tune is defined %}
+    {% for param, value in (haproxy_global.tune | flatten).items() -%}
+    tune.{{ param }} {{ value }}
+    {% endfor -%}
+{% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -23,6 +23,12 @@ empty: true
 #      format:
 #  ssl_default_bind_options:
 #  ssl_default_bind_ciphers:
+#  tune:
+#    chksize: 32768
+#    ssl:
+#      default-dh-param: 2048
+#    zlib:
+#      memlevel: 9
 #
 #haproxy_defaults:
 #  mode:


### PR DESCRIPTION
This commit adds support for setting `tune.chksize` and other parameters in `haproxy_global`.

Partially addresses #49.