### PR TITLE
Add backports support for Debian squeeze/jessie

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -57,15 +57,23 @@
     - socat
   when: ansible_os_family == 'RedHat'
 
-- name: 'Add haproxy apt repo'
+- name: 'Add haproxy apt repo (squeeze)'
   sudo: yes
   apt_repository:
-    repo: "deb http://http.debian.net/debian wheezy-backports main"
+    repo: deb http://http.debian.net/debian {{ ansible_distribution_release }}-backports-sloppy main
     state: present
     update_cache: yes
-  when: ansible_distribution_release == "wheezy"
+  when: ansible_distribution_release == 'squeeze'
 
-- name: 'Add haproxy apt repo'
+- name: Add haproxy apt repo (wheezy/jessie)
+  sudo: yes
+  apt_repository:
+    repo: deb http://http.debian.net/debian {{ ansible_distribution_release }}-backports main
+    state: present
+    update_cache: yes
+  when: ansible_distribution_release == 'wheezy' or ansible_distribution_release == 'jessie'
+
+- name: 'Add haproxy apt repo (Ubuntu)'
   sudo: yes
   apt_repository:
     repo: "ppa:vbernat/haproxy-1.5"


### PR DESCRIPTION
This commit extends the backports repository task to support Debian 6
"squeeze" and 8 "jessie".

It is backwards-compatible with the previous task which only supported
Debian 7 "wheezy".

**Duplicate of #37, moved to this repository as a feature branch.**