### PR TITLE
allow to access the  stats page on a dedicated ip and/or port

### DIFF
--- a/templates/listen.cfg
+++ b/templates/listen.cfg
@@ -6,7 +6,7 @@ listen {{ item.name }}
 
 {% endfor %}
 {% endif -%}
-{% if item.disabled is defined and item.disabled == true %}
+{% if item.disabled is defined and item.disabled | bool %}
     disabled
 {% endif -%}
 {% if item.description is defined %}
@@ -52,10 +52,10 @@ listen {{ item.name }}
 {% endfor %}
 {% endif -%}
 {% if item.stats is defined %}
-{% if item.stats.enabled is defined and item.stats.enabled == True %}
+{% if item.stats.enabled is defined and item.stats.enabled | bool %}
     stats enable
 {% endif -%}
-{% if item.stats.hide_version is defined and item.stats.hide_version == true %}
+{% if item.stats.hide_version is defined and item.stats.hide_version | bool %}
     stats hide-version
 {% endif -%}
 {% if item.stats.uri is defined %}

--- a/templates/listen.cfg
+++ b/templates/listen.cfg
@@ -51,3 +51,23 @@ listen {{ item.name }}
     timeout {{ entry.param }} {{ entry.value }}
 {% endfor %}
 {% endif -%}
+{% if item.stats is defined %}
+{% if item.stats.enabled is defined and item.stats.enabled == True %}
+    stats enable
+{% endif -%}
+{% if item.stats.hide_version is defined and item.stats.hide_version == true %}
+    stats hide-version
+{% endif -%}
+{% if item.stats.uri is defined %}
+    stats uri {{ item.stats.uri }}
+{% endif -%}
+{% if item.stats.realm is defined %}
+    stats realm {{ item.stats.realm }}
+{% endif -%}
+{% if item.stats.auth is defined %}
+    stats auth {{ item.stats.auth }}
+{% endif -%}
+{% if item.stats.refresh is defined %}
+    stats refresh {{ item.stats.refresh }}
+{% endif -%}
+{% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -140,3 +140,10 @@ empty: true
 #    timeout:
 #      - param:
 #        value:
+#    stats:
+#      enabled:
+#      hide_version:
+#      uri:
+#      realm:
+#      auth:
+#      refresh:


### PR DESCRIPTION
enable the creation of a dedicated stats-page as follows:

```
haproxy_listen:

  - name: stats
    bind:
      - ':8888'
    description: stats for site
    stats:
      enabled: true
      uri: /
      realm: Haproxy\ Stats
      auth: admin:secret
      refresh: 5s
```