### PR TITLE
add another two missing global settings

### DIFF
--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -45,4 +45,9 @@ global
 {% endif %}
 {% endfor %}
 {% endif %}
-
+{% if haproxy_global.ssl_default_bind_options is defined %}
+    ssl-default-bind-options {{ haproxy_global.ssl_default_bind_options }}
+{% endif -%}
+{% if haproxy_global.ssl_default_bind_ciphers is defined %}
+    ssl-default-bind-ciphers {{ haproxy_global.ssl_default_bind_ciphers }}
+{% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -21,6 +21,8 @@ empty: true
 #      level:
 #      minlevel:
 #      format:
+#  ssl_default_bind_options:
+#  ssl_default_bind_ciphers:
 #
 #haproxy_defaults:
 #  mode:


### PR DESCRIPTION
example usage:

```
# no-sslv3 to prevent SSLv3 Poodle vulnerability
  ssl_default_bind_options: no-sslv3 no-tls-tickets
  ssl_default_bind_ciphers: EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:EDH+aRSA:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4
```