### PR TITLE
Getting around Ansible order of ops for when/with_items (hopefully)

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -14,7 +14,7 @@
   template:
     src: "frontend.cfg"
     dest: "{{ etc_prefix }}/haproxy/frontends.d/{{ item.name }}.cfg"
-  with_items: "{{ haproxy_frontends }}"
+  with_items: "{{ haproxy_frontends|default([]) }}"
   when: haproxy_frontends is defined
 
 ## ASSEMBLE CONFIG - BACKEND
@@ -31,7 +31,7 @@
   template:
     src: "backend.cfg"
     dest: "{{ etc_prefix }}/haproxy/backends.d/{{ item.name }}.cfg"
-  with_items: "{{ haproxy_backends }}"
+  with_items: "{{ haproxy_backends|default([]) }}"
   when: haproxy_backends is defined
 
 ## ASSEMBLE CONFIG - LISTEN
@@ -48,7 +48,7 @@
   template:
     src: "listen.cfg"
     dest: "{{ etc_prefix }}/haproxy/listen.d/{{ item.name }}.cfg"
-  with_items: "{{ haproxy_listen }}"
+  with_items: "{{ haproxy_listen|default([]) }}"
   when: haproxy_listen is defined
 
 ## ASSEMBLE CONFIG - USERLIST
@@ -63,7 +63,7 @@
   template:
     src: userlist.cfg
     dest: "{{ etc_prefix }}/haproxy/userlists.d/{{ item.name }}.cfg"
-  with_items: "{{ haproxy_userlists }}"
+  with_items: "{{ haproxy_userlists|default([]) }}"
   when: haproxy_userlists is defined
 
 ## ASSEMBLE CONFIG - GLOBAL & DEFAULT


### PR DESCRIPTION
If haproxy_global[frontends, backends, etc] aren't defined then 'when' portion won't catch this case before with_items tries to eval the var so you'll get:

```
TASK [ansible-haproxy : Build up the frontends] ********************************
fatal: [ifx-lb01]: FAILED! => {"failed": true, "msg": "'haproxy_frontends' is undefined"}
```

Even though the module is defined to avoid this.  Providing a default empty array gets around this (and probably makes the 'when' unneeded).