### PR TITLE
Improve [global] ssl configuration. Provide default ssl configuration for 'A' rating in ssllabs checks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ haproxy_package_name: "{{ _haproxy_package_name }}"
 haproxy_extra_packages: "{{ _haproxy_extra_packages }}"
 
 haproxy_manage_config: true
+
+_haproxy_ssl_options: 'no-sslv3 no-tls-tickets'
+_haproxy_ssl_ciphers: 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS'
+
 haproxy_global:
   log:
     - address: /dev/log
@@ -19,6 +23,13 @@ haproxy_global:
   user: haproxy
   group: haproxy
   daemon: true
+  ssl_default_bind_options: '{{ _haproxy_ssl_options }}'
+  ssl_default_bind_ciphers: '{{ _haproxy_ssl_ciphers }}'
+  ssl_default_server_options: '{{ _haproxy_ssl_options }}'
+  ssl_default_server_ciphers: '{{ _haproxy_ssl_ciphers }}'
+  tune:
+    ssl:
+      default-dh-param: 2048
 
 haproxy_defaults:
   mode: http

--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -51,6 +51,12 @@ global
 {% if haproxy_global.ssl_default_bind_ciphers is defined %}
     ssl-default-bind-ciphers {{ haproxy_global.ssl_default_bind_ciphers }}
 {% endif -%}
+{% if haproxy_global.ssl_default_server_options is defined %}
+    ssl-default-server-options {{ haproxy_global.ssl_default_server_options }}
+{% endif -%}
+{% if haproxy_global.ssl_default_server_ciphers is defined %}
+    ssl-default-server-ciphers {{ haproxy_global.ssl_default_server_ciphers }}
+{% endif -%}
 {% if haproxy_global.tune is defined %}
     {% for param, value in (haproxy_global.tune | flatten).items() -%}
     tune.{{ param }} {{ value }}


### PR DESCRIPTION
Hello !

I was using this role and my fix before the change of maintainers. 
I decided to switch on the original fork with new maintainers.

In this PR, 3 commits : 
2 for closing issues #83  and #84 
1 for ability to have a good rating on ssllabs checkings. Maybe your prefer to switch this configuration in the vars/main.yml example ? 

Let me know ;)

