### PR TITLE
fix --check command

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,6 +9,7 @@
 - name: 'Check epel repo'
   shell: yum repolist | grep -qi EPEL
   register: epel_repo_check
+  check_mode: false
   when: ansible_pkg_mgr == "yum"
 
 - name: 'Add epel repo'


### PR DESCRIPTION
stops this error when ansible is run with the `--check` command

```
fatal: [x.x.x.x]: FAILED! => {"failed": true, "msg": "The conditional check 'ansible_pkg_mgr == \"yum\" and
 epel_repo_check is defined and epel_repo_check.rc != 0' failed. The error was: error while evaluating 
conditional (ansible_pkg_mgr == \"yum\" and epel_repo_check is defined and epel_repo_check.rc != 0):
 'dict object' has no attribute 'rc'\n\nThe error appears to have been in '/usr/local/etc/ansible/roles/devops-
coop.haproxy/tasks/install.yml': line 14, column 3, but may\nbe elsewhere in the file depending on the exact
 syntax problem.\n\nThe offending line appears to be:\n\n\n- name: 'Add epel repo'\n  ^ here\n"}
```