### PR TITLE
Add reqrep in the backend template.

### DIFF
--- a/templates/backend.cfg
+++ b/templates/backend.cfg
@@ -88,3 +88,9 @@
         errorfile {{ errorfile.code }} {{ errorfile.file }}
     {% endfor -%}
     {% endif -%}
+
+    {%- if item.reqrep is defined -%}
+    {%- for entry in item.reqrep -%}
+        reqrep {{ entry.search }} {{ entry.replace }} {%if entry.cond is defined -%}{{ entry.cond }}{% endif -%}
+    {% endfor -%}
+    {% endif -%}


### PR DESCRIPTION
i suggest to add this **reqrep** feature to the backend template. 

As the official documentation says : 

> The legacy statements reqrep and reqirep are still usefull for the cases not yet covered by the http-request rules.

My use case is to remove the grafana web context, and no HTTP header fields can be change with a `http-request replace-value`. So, and it works, I need to add this line to the backend definition:
```
reqrep ^([^\ ]*\ /)grafana[/]?(.*) \1\2
```



Sources:
https://www.haproxy.com/doc/aloha/7.0/haproxy/http_rewriting.html#rewrite-anywhere-in-the-request-using-regexes
https://en.wikipedia.org/wiki/List_of_HTTP_header_fields