### PR TITLE
Add reqadd,rspadd,reqrep,reqirep,rsprep,rspirep to backend template

### DIFF
--- a/templates/backend.cfg
+++ b/templates/backend.cfg
@@ -83,6 +83,42 @@
     {% endfor -%}
     {% endif -%}
 
+    {%- if item.reqadd is defined -%}
+    {%- for reqadd in item.reqadd -%}
+        reqadd {{ reqadd }}
+    {% endfor -%}
+    {% endif -%}
+
+    {%- if item.rspadd is defined -%}
+    {%- for rspadd in item.rspadd -%}
+        rspadd {{ rspadd }}
+    {% endfor -%}
+    {% endif -%}
+
+    {%- if item.reqrep is defined -%}
+    {%- for reqrep in item.reqrep -%}
+        reqrep {{ reqrep }}
+    {% endfor -%}
+    {% endif -%}
+
+    {%- if item.reqirep is defined -%}
+    {%- for reqirep in item.reqirep -%}
+        reqirep {{ reqirep }}
+    {% endfor -%}
+    {% endif -%}
+
+    {%- if item.rsprep is defined -%}
+    {%- for rsprep in item.rsprep -%}
+        rsprep {{ rsprep }}
+    {% endfor -%}
+    {% endif -%}
+
+    {%- if item.rspirep is defined -%}
+    {%- for rspirep in item.rspirep -%}
+        rspirep {{ rspirep }}
+    {% endfor -%}
+    {% endif -%}
+
     {% if item.appsession is defined -%}
         appsession {{ item.appsession }}
     {% endif -%}
@@ -90,11 +126,5 @@
     {%- if item.errorfile is defined -%}
     {%- for errorfile in item.errorfile -%}
         errorfile {{ errorfile.code }} {{ errorfile.file }}
-    {% endfor -%}
-    {% endif -%}
-
-    {%- if item.reqrep is defined -%}
-    {%- for entry in item.reqrep -%}
-        reqrep {{ entry.search }} {{ entry.replace }} {%if entry.cond is defined -%}{{ entry.cond }}{% endif -%}
     {% endfor -%}
     {% endif -%}

--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -49,7 +49,7 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
 
     {%- if item.reqadd is defined -%}
     {%- for reqadd in item.reqadd -%}
-         reqadd {{ reqadd }}
+        reqadd {{ reqadd }}
     {% endfor -%}
     {% endif -%}
 

--- a/templates/listen.cfg
+++ b/templates/listen.cfg
@@ -54,6 +54,36 @@ listen {{ item.name }}
     timeout {{ entry.param }} {{ entry.value }}
 {% endfor %}
 {% endif -%}
+{%- if item.reqadd is defined -%}
+{%- for reqadd in item.reqadd -%}
+    reqadd {{ reqadd }}
+{% endfor -%}
+{% endif -%}
+{%- if item.rspadd is defined -%}
+{%- for rspadd in item.rspadd -%}
+    rspadd {{ rspadd }}
+{% endfor -%}
+{% endif -%}
+{%- if item.reqrep is defined -%}
+{%- for reqrep in item.reqrep -%}
+    reqrep {{ reqrep }}
+{% endfor -%}
+{% endif -%}
+{%- if item.reqirep is defined -%}
+{%- for reqirep in item.reqirep -%}
+    reqirep {{ reqirep }}
+{% endfor -%}
+{% endif -%}
+{%- if item.rsprep is defined -%}
+{%- for rsprep in item.rsprep -%}
+    rsprep {{ rsprep }}
+{% endfor -%}
+{% endif -%}
+{%- if item.rspirep is defined -%}
+{%- for rspirep in item.rspirep -%}
+    rspirep {{ rspirep }}
+{% endfor -%}
+{% endif -%}
 {% if item.appsession is defined %}
     appsession {{ item.appsession }}
 {% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -150,6 +150,20 @@ empty: true
 #    errorfile:
 #      - code:
 #        file:
+#    reqadd:
+#      - "X-RequestHeader1:\\ some-value"
+#      - "X-RequestHeader2:\\ some-value"
+#    rspadd:
+#      - "X-ResponseHeader1:\\ some-value"
+#      - "X-ResponseHeader2:\\ some-value"
+#    reqrep:
+#      - "^Host:\ www.(.*)$ Host:\ \1 if host_www"
+#    reqirep:
+#      - "^Host:\ www.(.*)$ Host:\ \1 if host_www"
+#    rsprep:
+#      - "^Location:\ 127.0.0.1:8080 Location:\ www.mydomain.com"
+#    rspirep:
+#      - "^Location:\ 127.0.0.1:8080 Location:\ www.mydomain.com"
 #
 #haproxy_listen:
 #  - name:
@@ -181,6 +195,20 @@ empty: true
 #    timeout:
 #      - param:
 #        value:
+#    reqadd:
+#      - "X-RequestHeader1:\\ some-value"
+#      - "X-RequestHeader2:\\ some-value"
+#    rspadd:
+#      - "X-ResponseHeader1:\\ some-value"
+#      - "X-ResponseHeader2:\\ some-value"
+#    reqrep:
+#      - "^Host:\ www.(.*)$ Host:\ \1 if host_www"
+#    reqirep:
+#      - "^Host:\ www.(.*)$ Host:\ \1 if host_www"
+#    rsprep:
+#      - "^Location:\ 127.0.0.1:8080 Location:\ www.mydomain.com"
+#    rspirep:
+#      - "^Location:\ 127.0.0.1:8080 Location:\ www.mydomain.com"
 #    appsession: 'JSESSIONID len 52 timeout 3h'
 #    stats:
 #      enabled:


### PR DESCRIPTION
Adds missing request and response modification features to the backend template, bringing it to parity with the frontend one.

Breaking change for `reqrep` on backend: standardized to make this the same format as the frontend template - as in, it should be passed a list.