### PR TITLE
Add haproxy_resolvers configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Role Variables
 * `haproxy_defaults`
 
     Default settings for frontends, backends, and listen proxies.
+* `haproxy_resolvers`
+
+    A list of HAProxy resolvers.
 * `haproxy_backends`
 
     A list of HAProxy backends.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,7 @@ haproxy_defaults:
       - code: 504
         file: /etc/haproxy/errors/504.http
 
+haproxy_resolvers: []
 haproxy_backends: []
 haproxy_frontends: []
 haproxy_listen: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,33 @@
 ---
 
+## ASSEMBLE CONFIG - RESOLVERS
+
+- name: 'Create directory for the resolvers'
+  file:
+    path: "{{ haproxy_config_dir }}/resolvers.d"
+    state: directory
+
+- name: "List files for the resolvers"
+  find:
+    paths: "{{ haproxy_config_dir }}/resolvers.d"
+    patterns: "*.cfg"
+  register: directory_contents
+  changed_when: false
+
+- name: "Remove unmanaged files for the resolvers"
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  when: (item.path | basename) not in (haproxy_resolvers | json_query('[*].name') | map('regex_replace',  '(.*)', '\\1.cfg') | list)
+  with_items: "{{ directory_contents.files }}"
+
+- name: 'Build up the resolvers'
+  template:
+    src: "resolvers.cfg"
+    dest: "{{ haproxy_config_dir }}/resolvers.d/{{ item.name }}.cfg"
+  with_items: "{{ haproxy_resolvers }}"
+  when: haproxy_resolvers is defined
+
 ## ASSEMBLE CONFIG - FRONTEND
 
 - name: 'Create directory for the frontend'
@@ -112,8 +140,15 @@
 
 ## ASSEMBLE CONFIG - GLOBAL & DEFAULT
 
-- name: 'Create  the compiled folder'
-  file: path={{ haproxy_config_dir }}/compiled state=directory
+- name: 'Delete the compiled folder'
+  file:
+    path: "{{ haproxy_config_dir }}/compiled"
+    state: absent
+
+- name: 'Create the compiled folder'
+  file:
+    path: "{{ haproxy_config_dir }}/compiled"
+    state: directory
 
 - name: 'Build up the global config'
   template:
@@ -130,25 +165,30 @@
 
 ## ASSEMBLE FINAL CONFIG
 
+- name: 'Assemble the resolvers sections configuration file'
+  assemble:
+    src: "{{ haproxy_config_dir }}/resolvers.d"
+    dest: "{{ haproxy_config_dir }}/compiled/03-resolvers.cfg"
+
 - name: 'Assemble the backends configuration file'
   assemble:
     src: "{{ haproxy_config_dir }}/backends.d"
-    dest: "{{ haproxy_config_dir }}/compiled/03-backends.cfg"
+    dest: "{{ haproxy_config_dir }}/compiled/04-backends.cfg"
 
 - name: 'Assemble the frontends configuration file'
   assemble:
     src: "{{ haproxy_config_dir }}/frontends.d"
-    dest: "{{ haproxy_config_dir }}/compiled/04-frontends.cfg"
+    dest: "{{ haproxy_config_dir }}/compiled/05-frontends.cfg"
 
 - name: 'Assemble the listen sections configuration file'
   assemble:
     src: "{{ haproxy_config_dir }}/listen.d"
-    dest: "{{ haproxy_config_dir }}/compiled/05-listen.cfg"
+    dest: "{{ haproxy_config_dir }}/compiled/06-listen.cfg"
 
 - name: 'Assemble the userlists sections configuration file'
   assemble:
     src: "{{ haproxy_config_dir }}/userlists.d"
-    dest: "{{ haproxy_config_dir }}/compiled/06-userlists.cfg"
+    dest: "{{ haproxy_config_dir }}/compiled/07-userlists.cfg"
 
 - name: 'Assemble the final configuration file'
   assemble:

--- a/templates/resolvers.cfg
+++ b/templates/resolvers.cfg
@@ -1,0 +1,18 @@
+#{{ ansible_managed }}
+resolvers {{ item.name }}
+    {% if item.nameservers is defined -%}
+    {%- for nameserver in item.nameservers -%}
+        nameserver {{ nameserver.name }} {{ nameserver.ip }}:{{ nameserver.port }}
+    {% endfor -%}
+    {% endif -%}
+    {% if item.hold is defined -%}
+    {%- for hold in item.hold -%}
+        hold {{ hold.status }} {{ hold.period }}
+    {% endfor -%}
+    {% endif -%}
+    {% if item.resolve_retries is defined -%}
+        resolve_retries {{ item.resolve_retries }}
+    {% endif -%}
+    {% if item.timeout_retry is defined -%}
+        timeout retry {{ timeout.timeout_retry }}
+    {% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -63,6 +63,18 @@ empty: true
 #    expect:
 #    send_state:
 #
+#haproxy_resolvers:
+#  - name:
+#    nameservers:
+#      - name:
+#        ip:
+#        port:
+#    hold:
+#      - status:
+#        period:
+#    resolve_retries:
+#    timeout_retry:
+#
 #haproxy_frontends:
 #  - name:
 #    ip:


### PR DESCRIPTION
Adds the `haproxy_resolvers` variable for the use of [DNS Resolvers](https://cbonte.github.io/haproxy-dconv/1.6/configuration.html#5.3.2) in haproxy 1.6+, which permits runtime DNS resolution. Also added a task to clear the compiled folder, as renumbering of the sections was required to keep a sane compiled config order.