### PR TITLE
Add maxconn to listener template

### DIFF
--- a/templates/listen.cfg
+++ b/templates/listen.cfg
@@ -18,6 +18,9 @@ listen {{ item.name }}
 
 {% endfor %}
 {% endif %}
+{% if item.maxconn is defined -%}
+    maxconn {{ item.maxconn }}
+{% endif -%}
 {% if item.balance is defined %}
     balance {{ item.balance }}
 {% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -173,6 +173,7 @@ empty: true
 #      ciphers: 'RC4-SHA:AES128-SHA:AES:!ADH:!aNULL:!DH:!EDH:!eNULL'
 #    disabled:
 #    description:
+#    maxconn:
 #    balance:
 #    cookie:
 #    log:


### PR DESCRIPTION
Adds the missing `maxconn` option to the listener template.