### PR TITLE
place acl rules in front of monitor rules

### DIFF
--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -24,6 +24,12 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
     {% endfor %}
     {% endif -%}
 
+    {%- if item.acl is defined -%}
+    {%- for acl in item.acl -%}
+         acl {{ acl.name }} {{ acl.condition }}
+    {% endfor -%}
+    {% endif -%}
+
     {%- if item.monitor is defined -%}
        {% if item.monitor.uri is defined -%}
             monitor-uri {{ item.monitor.uri }}
@@ -33,12 +39,6 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
             monitor fail {{ condition }}
          {% endfor %}
        {% endif %}
-    {% endif -%}
-
-    {%- if item.acl is defined -%}
-    {%- for acl in item.acl -%}
-         acl {{ acl.name }} {{ acl.condition }}
-    {% endfor -%}
     {% endif -%}
 
     {%- if item.capture is defined -%}


### PR DESCRIPTION
To use a named ACL in a monitor condition, it should be placed before the monitor definition