### PR TITLE
ansible removes newlines

### DIFF
--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:False
 {%- import '_macros.j2' as macros with context -%}
 
 #{{ ansible_managed }}


### PR DESCRIPTION
ansible removes newlines which causes tcp-request configs to overlap
with backends