### PR TITLE
change order of some rules to avoid warnings

### DIFF
--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -47,6 +47,20 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
        {% endfor %}
     {% endif -%}
 
+    {%- if item.tcp_request is defined -%}
+    {%- for request in item.tcp_request -%}
+        tcp-request {{ request.param }} {{ request.value }}{% if request.condition is defined %} {{ request.condition }}{% endif %}
+    {% endfor -%}
+    {% endif -%}
+
+    {%- if item.http_request is defined -%}
+        {{ macros.http_request(item.http_request) }}
+    {%- endif -%}
+
+    {%- if item.http_response is defined -%}
+        {{ macros.http_response(item.http_response) }}
+    {%- endif -%}
+
     {%- if item.reqadd is defined -%}
     {%- for reqadd in item.reqadd -%}
         reqadd {{ reqadd }}
@@ -104,20 +118,6 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
         redirect {{ redirect }}
     {% endfor -%}
     {% endif -%}
-
-    {%- if item.tcp_request is defined -%}
-    {%- for request in item.tcp_request -%}
-        tcp-request {{ request.param }} {{ request.value }}{% if request.condition is defined %} {{ request.condition }}{% endif %}
-    {% endfor -%}
-    {% endif -%}
-
-    {%- if item.http_request is defined -%}
-        {{ macros.http_request(item.http_request) }}
-    {%- endif -%}
-
-    {%- if item.http_response is defined -%}
-        {{ macros.http_response(item.http_response) }}
-    {%- endif -%}
 
     {%- if item.default_backend is defined -%}
         default_backend {{ item.default_backend }}


### PR DESCRIPTION
place tcp-request, http-request and http-response rules in front of reqxxx and rspxxx rules to avoid warnings like:

[WARNING] 327/172846 (4677) : parsing [/etc/haproxy/haproxy.cfg:110] : a 'http-request' rule placed after a 'reqadd' rule will still be processed before.