### PR TITLE
Support global option log-send-hostname

### DIFF
--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -45,6 +45,11 @@ global
 {% endif %}
 {% endfor %}
 {% endif %}
+
+{% if haproxy_global.log_send_hostname is defined %}
+    log-send-hostname {{ haproxy_global.log_send_hostname }}
+{% endif %}
+
 {% if haproxy_global.ssl_default_bind_options is defined %}
     ssl-default-bind-options {{ haproxy_global.ssl_default_bind_options }}
 {% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -21,6 +21,7 @@ empty: true
 #      level:
 #      minlevel:
 #      format:
+#  log_send_hostname:
 #  ssl_default_bind_options:
 #  ssl_default_bind_ciphers:
 #  tune:


### PR DESCRIPTION
Adds the `log-send-hostname` global configuration option.