### PR TITLE
Allow insecure-passwords in userlists.

### DIFF
--- a/templates/userlist.cfg
+++ b/templates/userlist.cfg
@@ -8,7 +8,11 @@ userlist {{ item.name }}
 {% endif %}
 {% if item.users is defined %}
 {% for user in item.users %}
+    {% if user.password is defined %}
     user {{ user.name }} password {{ user.password }}{% if user.groups is defined %} groups {{ ','.join(user.groups) }}{% endif %}
-
+    {% elif user.insecure_password is defined %}
+    user {{ user.name }} insecure-password {{ user.insecure_password }}{% if user.groups is defined %} groups {{ ','.join(user.groups) }}{% endif %}
+    {% endif %}
 {% endfor %}
+
 {% endif %}


### PR DESCRIPTION
Allow the `userlist` block to be populated with `insecure-password`s instead of encrypted `password`s. This is useful combined with strong permissions on haproxy.conf as the encrypted format is not well-defined and easy to implement in ansible.